### PR TITLE
feat: make api receive `current_block_number` and `round_pubkey_bytes…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,6 +2740,7 @@ name = "murmur-api"
 version = "0.1.0"
 dependencies = [
  "bcrypt",
+ "hex",
  "murmur-lib",
  "rocket",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde_cbor = "0.11.2"
 sp-core = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", features = ["bls-experimental"] }
 subxt-signer = "0.35.2"
 subxt = "0.35.2"
+hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This is a simple API that allows you to interact with [Murmur Core](https://github.com/ideal-lab5/murmur).
 
+## Usage
+
+```bash
+cargo run
+```
+
 ## Environment Variables
 
 In live environments you should set the following environment variables:

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use subxt_signer::sr25519::dev;
 use utils::{check_cookie, derive_seed, get_ephem_msk, get_salt, MurmurError};
 
 #[derive(Deserialize)]
-struct LoginRequest {
+struct AuthRequest {
 	username: String,
 	password: String,
 }
@@ -52,11 +52,11 @@ struct NewRequest {
 	round_pubkey_bytes: String,
 }
 
-#[post("/authenticate", data = "<login_request>")]
+#[post("/authenticate", data = "<auth_request>")]
 /// Authenticate the user and start a session
-async fn authenticate(login_request: Json<LoginRequest>, cookies: &CookieJar<'_>) -> &'static str {
-	let username = &login_request.username;
-	let password = &login_request.password;
+async fn authenticate(auth_request: Json<AuthRequest>, cookies: &CookieJar<'_>) -> &'static str {
+	let username = &auth_request.username;
+	let password = &auth_request.password;
 	let seed = derive_seed(username, password, &get_salt());
 
 	cookies.add(Cookie::new("username", username.clone()));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,10 +20,10 @@ use rocket::http::{CookieJar, Status};
 pub(crate) async fn check_cookie<'a, F, Fut, R>(
 	cookies: &'a CookieJar<'_>,
 	callback: F,
-) -> Result<R, Status>
+) -> Result<R, (Status, String)>
 where
 	F: FnOnce(&'a str, &'a str) -> Fut,
-	Fut: std::future::Future<Output = Result<R, Status>>,
+	Fut: std::future::Future<Output = Result<R, (Status, String)>>,
 {
 	let username = cookies.get("username");
 	let seed = cookies.get("seed");
@@ -33,7 +33,7 @@ where
 			let seed = seed_cookie.value();
 			callback(username, seed).await
 		},
-		_ => Err(Status::Forbidden),
+		_ => Err((Status::Forbidden, "Not logged in".to_string())),
 	}
 }
 
@@ -41,4 +41,24 @@ pub(crate) fn derive_seed(password: &str, username: &str, salt: &str) -> String 
 	hash_with_salt(format!("{}:{}", username, password), 4, salt.as_bytes())
 		.unwrap()
 		.to_string()
+}
+
+pub(crate) struct MurmurError(pub(crate) murmur::Error);
+
+impl std::fmt::Display for MurmurError {
+    #[allow(unreachable_patterns)]
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self.0 {
+			murmur::Error::ExecuteError => write!(f, "Murmur: Execute error"),
+			murmur::Error::MMRError => write!(f, "Murmur: MMR error"),
+			murmur::Error::InconsistentStore => write!(f, "Murmur: Inconsistent store"),
+			murmur::Error::NoLeafFound => write!(f, "Murmur: No leaf found"),
+			murmur::Error::NoCiphertextFound => write!(f, "Murmur: No ciphertext found"),
+			murmur::Error::TlockFailed => write!(f, "Murmur: Tlock failed"),
+			murmur::Error::InvalidBufferSize => write!(f, "Murmur: Invalid buffer size"),
+			murmur::Error::InvalidSeed => write!(f, "Murmur: Invalid seed"),
+			murmur::Error::InvalidPubkey => write!(f, "Murmur: Invalid pubkey"),
+			_ => write!(f, "Murmur: Unknown error"),
+		}
+	}
 }


### PR DESCRIPTION
…` in the requests